### PR TITLE
Add correct release version to PyStageLinQ messages

### DIFF
--- a/PyStageLinQ/PyStageLinQ.py
+++ b/PyStageLinQ/PyStageLinQ.py
@@ -58,7 +58,7 @@ class PyStageLinQ:
             DeviceName=self.name,
             ConnectionType=ConnectionTypes.HOWDY,
             SwName="Python",
-            SwVersion="1.0.0",
+            SwVersion="0.0.1",
             ReqServicePort=self.REQUESTSERVICEPORT,
         )
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@ Problems on Linux should now be solved.
 PyStageLinQ will now listen to address "255.255.255.255" on all interfaces, and transmit discovery frames on either the
 interface specified by `PyStageLinQ(..., ip=)` or on all interfaces if `ip` is not set.
 
+PyStageLinQ will now use its release version when sending discovery frames.
+
 ### Added
 More logging output in PyStageLinQ.py.
 

--- a/make_release.sh
+++ b/make_release.sh
@@ -9,6 +9,7 @@ echo "Version detected from git tag: $new_ver"
 echo "Updating pyproject.toml"
 sed -i 's/version = "0.0.0"/version = "'$new_ver'"/' pyproject.toml
 sed -i 's/release = "0.0.0"/release = "'$new_ver'"/' docs/conf.py
+sed -i 's/SwVersion="0.0.1"/SwVersion="'$new_ver'"/' PyStageLinQ/PyStageLinQ.py
 
 
 rm dist/* -f

--- a/tests/unit/test_unit_PyStageLinQ.py
+++ b/tests/unit/test_unit_PyStageLinQ.py
@@ -49,7 +49,7 @@ def test_init_values(dummy_pystagelinq, dummy_ip):
     assert dummy_pystagelinq.discovery_info.DeviceName == name
     assert dummy_pystagelinq.discovery_info.ConnectionType is "DISCOVERER_HOWDY_"
     assert dummy_pystagelinq.discovery_info.SwName == "Python"
-    assert dummy_pystagelinq.discovery_info.SwVersion == "1.0.0"
+    assert dummy_pystagelinq.discovery_info.SwVersion == "0.0.1"
     assert (
         dummy_pystagelinq.discovery_info.ReqServicePort
         == dummy_pystagelinq.REQUESTSERVICEPORT
@@ -140,7 +140,7 @@ def test_internal_stop(dummy_pystagelinq, monkeypatch):
                 DeviceName=dummy_pystagelinq.name,
                 ConnectionType="DISCOVERER_EXIT_",
                 SwName="Python",
-                SwVersion="1.0.0",
+                SwVersion="0.0.1",
                 ReqServicePort=dummy_pystagelinq.REQUESTSERVICEPORT,
             )
         )


### PR DESCRIPTION
PyStageLinQ will now post correct version when sending discovery frames. This is only valid for PyPi released versions.