### PR TITLE
refactor: adding random seed tests

### DIFF
--- a/tests/unit/test_unit_messageClasses_Discovery.py
+++ b/tests/unit/test_unit_messageClasses_Discovery.py
@@ -4,6 +4,8 @@ import PyStageLinQ.Token
 import PyStageLinQ.DataClasses
 import random
 
+random.seed(35)
+
 from PyStageLinQ.ErrorCodes import PyStageLinQError
 
 device_name_dummy = "AAAA"


### PR DESCRIPTION
Hello, while reviewing the code for an ongoing research project, I noticed that many tests in the project use random operations without setting a seed, which is necessary to ensure consistent results across different runs.

This pull request introduces a fixed seed value (seed(35)) in the global test environment. By doing so, it ensures reproducible random operations during testing, improving consistency and helping to prevent potential flakiness in CI results.

We came across this issue while using the project in a research study. Thank you for your time and consideration.